### PR TITLE
Resolve test failures

### DIFF
--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -20,10 +20,12 @@ Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provid
       # / ha-all .* all {"ha-mode":"all","ha-sync-mode":"automatic"} 0 << This is for RabbitMQ v >= 3.7.0
       if Puppet::Util::Package.versioncmp(rabbitmq_version, '3.7') >= 0
         regex = %r{^(\S+)\s+(\S+)\s+(\S+)\s+(all|exchanges|queues)?\s+(\S+)\s+(\d+)$}
-        applyto_index, pattern_index = 4, 3
+        applyto_index = 4
+        pattern_index = 3
       else
         regex = %r{^(\S+)\s+(\S+)\s+(all|exchanges|queues)?\s*(\S+)\s+(\S+)\s+(\d+)$}
-        applyto_index, pattern_index = 3, 4
+        applyto_index = 3
+        pattern_index = 4
       end
 
       policy_list.split(%r{\n}).each do |line|

--- a/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
+provider_class = Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl)
+describe provider_class do
   let(:resource) do
     Puppet::Type.type(:rabbitmq_policy).new(
       name: 'ha-all@/',
       pattern: '.*',
       definition: {
         'ha-mode' => 'all'
-      },
-      provider: described_class.name
+      }
     )
   end
-  let(:provider) { resource.provider }
+  let(:provider) { provider_class.new(resource) }
 
   after do
     described_class.instance_variable_set(:@policies, nil)
@@ -47,7 +47,7 @@ describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
 
   context 'with RabbitMQ version >=3.7.0' do
     it 'matches policies from list' do
-      provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.7.0"}'
+      provider.class.expects(:rabbitmq_version).returns '3.7.0'
       provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns <<-EOT
 / ha-all .* all {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test .* exchanges {"ha-mode":"all"} 0
@@ -64,7 +64,7 @@ EOT
 
   context 'with RabbitMQ version >=3.2.0 and < 3.7.0' do
     it 'matches policies from list' do
-      provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.6.9"}'
+      provider.class.expects(:rabbitmq_version).returns '3.6.9'
       provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns <<-EOT
 / ha-all all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test exchanges .* {"ha-mode":"all"} 0
@@ -81,7 +81,7 @@ EOT
 
   context 'with RabbitMQ version <3.2.0' do
     it 'matches policies from list (<3.2.0)' do
-      provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.1.5"}'
+      provider.class.expects(:rabbitmq_version).returns '3.1.5'
       provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns <<-EOT
 / ha-all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test .* {"ha-mode":"all"} 0


### PR DESCRIPTION
@fatmcgav I _think_ this might help with the test failures and rubocop errors in
https://github.com/voxpupuli/puppet-rabbitmq/pull/676
Another fix that might work instead is to take them out of the context blocks, but if this works, should be better. Not sure if there's a way to test this in Travis without merging it, but you could revert back to before merging and force-push if it doesn't...